### PR TITLE
Specify an empty api_key so that running uv run run_demo.py works

### DIFF
--- a/2025/Agents/web_agent/agent.py
+++ b/2025/Agents/web_agent/agent.py
@@ -67,7 +67,7 @@ class DemoAgent(Agent):
         if not (use_html or use_axtree):
             raise ValueError(f"Either use_html or use_axtree must be set to True.")
 
-        self.openai_client = openai.OpenAI(base_url="http://89.169.109.91:8000/v1")
+        self.openai_client = openai.OpenAI(base_url="http://89.169.109.91:8000/v1", api_key="")
 
         self.action_set = HighLevelActionSet(
             subsets=["chat", "tab", "nav", "bid", "infeas"],  # define a subset of the action space


### PR DESCRIPTION
Specify an empty api_key so that running uv run run_demo.py does not fail.